### PR TITLE
Convert rhel2 to image mode on setup automation and reconfigure rhel/root user 

### DIFF
--- a/runtime-automation/02-image-mode/setup-rhel2.sh
+++ b/runtime-automation/02-image-mode/setup-rhel2.sh
@@ -5,8 +5,3 @@ echo "Starting module called 02-image-mode" >> /tmp/progress.log
 ## Related to https://github.com/bootc-dev/bootc/issues/1204
 sed -ie 's/enable_partial_images = "true"/enable_partial_images = "false"/' /etc/containers/storage.conf
 
-## Convert the system to Image Mode
-podman run --rm --privileged -v /dev:/dev -v /var/lib/containers:/var/lib/containers -v /:/target --pid=host --security-opt label=type:unconfined_t quay.io/toharris/rhel-bootc:summit-2025 bootc install to-existing-root --root-ssh-authorized-keys /target/root/.ssh/authorized_keys --acknowledge-destructive
-
-## Reboot system
-reboot

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -43,6 +43,7 @@
     ansible.builtin.copy:
       dest: "/tmp/{{ guid }}key.pem"
       content: "{{ r_slurp['content'] | b64decode }}"
+      mode: 0600
     delegate_to: localhost
 
   

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -121,6 +121,7 @@
     ansible.builtin.add_host:
       name: "rhel2"
       ansible_ssh_pass: ""
+      ansible_ssh_user: "root"
       ansible_ssh_private_key_file: "/tmp/{{ guid }}key.pem"
 
 - name: Post task(s) for rhel2

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -117,7 +117,7 @@
     ansible.builtin.add_host:
       name: "rhel2"
       ansible_ssh_private_key_file: "/tmp/{{ guid }}key.pem"
-      ansible_ssh_host: "{{ rhel2 }}"
+      ansible_ssh_host: "rhel2"
       ansible_ssh_port: "{{ lookup('ansible.builtin.env', 'BASTION_PORT') }}"
       ansible_ssh_user: "{{ lookup('ansible.builtin.env', 'BASTION_USER') }}"
       ansible_ssh_pass: "{{ lookup('ansible.builtin.env', 'BASTION_PASSWORD') }}"

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -116,7 +116,7 @@
   - name: Add rhel2 host with SSH key
     ansible.builtin.add_host:
       name: "rhel2"
-      ansible_ssh_private_keyfile: "/tmp/{{ guid }}key.pem"
+      ansible_ssh_private_key_file: "/tmp/{{ guid }}key.pem"
 
 - name: Post task(s) for rhel2
   hosts: rhel2

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -23,6 +23,21 @@
       - rhel1
       - rhel2
       - satellite-2
+
+- name: Pre task(s) for rhel2
+  hosts: rhel2
+  gather_facts: false
+  vars:
+    guid: "{{ lookup('ansible.builtin.env', 'GUID') }}"
+  tasks:
+  - name: Fetch private SSH key to be used later
+    ansible.builtin.fetch:
+      src: "/home/rhel/.ssh/{{ guid }}.pem"
+      dest: "/tmp/{{ guid }}.pem"
+      flat: yes
+  
+
+  
 - name: Demo Playbook for the ansible-runner API
   hosts: all:!localhost
   gather_facts: false
@@ -87,3 +102,39 @@
     - r_result is defined
     - r_result.rc != 0
 
+- name: Create inventory
+  hosts: localhost
+  gather_facts: false
+  vars:
+    guid: "{{ lookup('ansible.builtin.env', 'GUID') }}"
+  tasks:
+  - name: Add node2 host with SSH key
+    ansible.builtin.add_host:
+      name: "node2"
+      ansible_ssh_host: ""
+      ansible_ssh_user: "{{ lookup('ansible.builtin.env', 'BASTION_USER') }}"
+      ansible_ssh_pass: ""
+      ansible_ssh_private_keyfile: "/tmp/{{ guid }}.pem"
+
+- name: Post task(s) for rhel2
+  hosts: rhel2
+  gather_facts: false
+  vars:
+    rhel_user_password: "{{ lookup('ansible.builtin.env', 'BASTION_PASSWORD') }}"
+  tasks:
+    - name: Ensure user 'rhel' exists and has the specified password
+      ansible.builtin.user:
+        name: rhel
+        password: "{{ rhel_user_password | password_hash('sha512') }}" # Generates SHA512 hash from prompted password
+        state: present
+        shell: /bin/bash         # Set default shell
+        create_home: yes         # Ensure home directory is created
+        home: /home/rhel         # Specify home directory path
+        groups: wheel            # Add user to the 'wheel' group (for sudo access, typically)
+        append: yes              # Append to existing groups if user already exists
+
+    - name: Ensure user 'root' has the specified password
+      become: true
+      ansible.builtin.user:
+        name: root
+        password: "{{ rhel_user_password | password_hash('sha512') }}" # Generates SHA512 hash from prompted password

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -81,7 +81,6 @@
     register: r_result
 
   - name: Execute module_stage-host.sh if it exists
-    ignore_errors: true
     when: r_script_test.stat.exists
     shell: "sh -x /tmp/setup-scripts/setup-{{ ansible_host }}.sh > /tmp/setup-scripts/setup-{{ ansible_host }}.log 2>&1"
     become: true
@@ -105,12 +104,12 @@
       var: r_result
     when: r_result is defined
 
-  #- name: Fail if stage was failed
-  #  ansible.builtin.fail:
-  #    msg: "Setup failed"
-  #  when:
-  #  - r_result is defined
-  #  - r_result.rc != 0
+  - name: Fail if stage was failed
+    ansible.builtin.fail:
+      msg: "Setup failed"
+    when:
+    - r_result is defined
+    - r_result.rc != 0
 
 - name: Create inventory
   hosts: localhost

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -116,9 +116,6 @@
   - name: Add rhel2 host with SSH key
     ansible.builtin.add_host:
       name: "rhel2"
-      ansible_ssh_host: "rhel2"
-      ansible_ssh_user: "root"
-      ansible_ssh_pass: ""
       ansible_ssh_private_keyfile: "/tmp/{{ guid }}key.pem"
 
 - name: Post task(s) for rhel2

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -104,12 +104,12 @@
       var: r_result
     when: r_result is defined
 
-  - name: Fail if stage was failed
-    ansible.builtin.fail:
-      msg: "Setup failed"
-    when:
-    - r_result is defined
-    - r_result.rc != 0
+  #- name: Fail if stage was failed
+  #  ansible.builtin.fail:
+  #    msg: "Setup failed"
+  #  when:
+  #  - r_result is defined
+  #  - r_result.rc != 0
 
 - name: Create inventory
   hosts: localhost
@@ -121,12 +121,7 @@
     when: false
     ansible.builtin.add_host:
       name: "rhel2"
-      #ansible_ssh_private_key_file: "/tmp/{{ guid }}key.pem"
-      ansible_ssh_host: "rhel2"
-      ansible_ssh_port: "{{ lookup('ansible.builtin.env', 'BASTION_PORT') }}"
-      ansible_ssh_user: "{{ lookup('ansible.builtin.env', 'BASTION_USER') }}"
-      ansible_ssh_pass: "{{ lookup('ansible.builtin.env', 'BASTION_PASSWORD') }}"
-      ansible_python_interpreter: /usr/libexec/platform-python
+      ansible_ssh_private_key_file: "/tmp/{{ guid }}key.pem"
 
 - name: Post task(s) for rhel2
   hosts: rhel2

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -118,6 +118,7 @@
     guid: "{{ lookup('ansible.builtin.env', 'GUID') }}"
   tasks:
   - name: Add rhel2 host with SSH key
+    when: false
     ansible.builtin.add_host:
       name: "rhel2"
       #ansible_ssh_private_key_file: "/tmp/{{ guid }}key.pem"

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -30,6 +30,10 @@
   vars:
     guid: "{{ lookup('ansible.builtin.env', 'GUID') }}"
   tasks:
+  - debug: var=guid
+  - command: ls -R
+    register: r_ls
+  - debug: var=r_rls
   - name: Fetch private SSH key to be used later
     ansible.builtin.fetch:
       src: "/home/rhel/.ssh/{{ guid }}.pem"

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -117,10 +117,15 @@
     ansible.builtin.add_host:
       name: "rhel2"
       ansible_ssh_private_key_file: "/tmp/{{ guid }}key.pem"
+      ansible_ssh_host: "{{ rhel2 }}"
+      ansible_ssh_port: "{{ lookup('ansible.builtin.env', 'BASTION_PORT') }}"
+      ansible_ssh_user: "{{ lookup('ansible.builtin.env', 'BASTION_USER') }}"
+      ansible_ssh_pass: "{{ lookup('ansible.builtin.env', 'BASTION_PASSWORD') }}"
+      ansible_python_interpreter: /usr/libexec/platform-python
 
 - name: Post task(s) for rhel2
   hosts: rhel2
-  gather_facts: false
+  gather_facts: true
   become: true
   vars:
     rhel_user_password: "{{ lookup('ansible.builtin.env', 'BASTION_PASSWORD') }}"

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -164,9 +164,3 @@
         name: sshd
         state: reloaded
 
-- name: Create inventory
-  hosts: localhost
-  gather_facts: false
-  tasks:
-    - ansible.builtin.pause:
-        minutes: 1

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -77,6 +77,7 @@
 
   - name: Execute module_stage-host.sh if it exists
     when: r_script_test.stat.exists
+    ignore_errors: true
     shell: "sh -x /tmp/setup-scripts/setup-{{ ansible_host }}.sh > /tmp/setup-scripts/setup-{{ ansible_host }}.log 2>&1"
     become: true
     register: r_result
@@ -144,3 +145,9 @@
       ansible.builtin.user:
         name: root
         password: "{{ rhel_user_password | password_hash('sha512') }}" # Generates SHA512 hash from prompted password
+- name: Create inventory
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - ansible.builtin.pause:
+        minutes: 1

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -31,7 +31,7 @@
     guid: "{{ lookup('ansible.builtin.env', 'GUID') }}"
   tasks:
   - debug: var=guid
-  - command: ls -R
+  - command: ls -R /home/rhel/.ssh/
     register: r_ls
   - debug: var=r_ls
   - name: Fetch private SSH key to be used later

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -123,13 +123,13 @@
 - name: Post task(s) for rhel2
   hosts: rhel2
   gather_facts: false
+  become: true
   vars:
     rhel_user_password: "{{ lookup('ansible.builtin.env', 'BASTION_PASSWORD') }}"
   tasks:
     - name: Reboot the system
       ansible.builtin.reboot:
     - name: Ensure user 'rhel' exists and has the specified password
-      become: true
       ansible.builtin.user:
         name: rhel
         password: "{{ rhel_user_password | password_hash('sha512') }}" # Generates SHA512 hash from prompted password
@@ -141,7 +141,6 @@
         append: yes              # Append to existing groups if user already exists
 
     - name: Ensure user 'root' has the specified password
-      become: true
       ansible.builtin.user:
         name: root
         password: "{{ rhel_user_password | password_hash('sha512') }}" # Generates SHA512 hash from prompted password

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -112,9 +112,9 @@
   vars:
     guid: "{{ lookup('ansible.builtin.env', 'GUID') }}"
   tasks:
-  - name: Add node2 host with SSH key
+  - name: Add rhel2 host with SSH key
     ansible.builtin.add_host:
-      name: "node2"
+      name: "rhel2"
       ansible_ssh_host: ""
       ansible_ssh_user: "root"
       ansible_ssh_pass: ""

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -116,7 +116,7 @@
     ansible.builtin.add_host:
       name: "node2"
       ansible_ssh_host: ""
-      ansible_ssh_user: "root
+      ansible_ssh_user: "root"
       ansible_ssh_pass: ""
       ansible_ssh_private_keyfile: "/tmp/{{ guid }}key.pem"
 

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -126,7 +126,10 @@
   vars:
     rhel_user_password: "{{ lookup('ansible.builtin.env', 'BASTION_PASSWORD') }}"
   tasks:
+    - name: Reboot the system
+      ansible.builtin.reboot:
     - name: Ensure user 'rhel' exists and has the specified password
+      become: true
       ansible.builtin.user:
         name: rhel
         password: "{{ rhel_user_password | password_hash('sha512') }}" # Generates SHA512 hash from prompted password

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -116,7 +116,7 @@
     ansible.builtin.add_host:
       name: "node2"
       ansible_ssh_host: ""
-      ansible_ssh_user: "{{ lookup('ansible.builtin.env', 'BASTION_USER') }}"
+      ansible_ssh_user: "root
       ansible_ssh_pass: ""
       ansible_ssh_private_keyfile: "/tmp/{{ guid }}key.pem"
 

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -30,10 +30,7 @@
   vars:
     guid: "{{ lookup('ansible.builtin.env', 'GUID') }}"
   tasks:
-  - debug: var=guid
-  - command: ls -R /home/rhel/.ssh/
-    register: r_ls
-  - debug: var=r_ls
+
   - name: Fetch private SSH key to be used later
     ansible.builtin.slurp:
       src: "/home/rhel/.ssh/{{ guid }}key.pem"

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -35,11 +35,15 @@
     register: r_ls
   - debug: var=r_ls
   - name: Fetch private SSH key to be used later
-    ansible.builtin.fetch:
+    ansible.builtin.slurp:
       src: "/home/rhel/.ssh/{{ guid }}key.pem"
+    register: r_slurp
+    
+  - name: Save to tmp
+    ansible.builtin.copy:
       dest: "/tmp/{{ guid }}key.pem"
-      flat: yes
-  
+      content: "{{ r_slurp['content'] | b64decode }}"
+    delegate_to: localhost
 
   
 - name: Demo Playbook for the ansible-runner API

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -120,7 +120,7 @@
   - name: Add rhel2 host with SSH key
     ansible.builtin.add_host:
       name: "rhel2"
-      ansible_ssh_private_key_file: "/tmp/{{ guid }}key.pem"
+      #ansible_ssh_private_key_file: "/tmp/{{ guid }}key.pem"
       ansible_ssh_host: "rhel2"
       ansible_ssh_port: "{{ lookup('ansible.builtin.env', 'BASTION_PORT') }}"
       ansible_ssh_user: "{{ lookup('ansible.builtin.env', 'BASTION_USER') }}"

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -80,6 +80,7 @@
     register: r_result
 
   - name: Execute module_stage-host.sh if it exists
+    ignore_errors: true
     when: r_script_test.stat.exists
     shell: "sh -x /tmp/setup-scripts/setup-{{ ansible_host }}.sh > /tmp/setup-scripts/setup-{{ ansible_host }}.log 2>&1"
     become: true
@@ -103,12 +104,12 @@
       var: r_result
     when: r_result is defined
 
-  - name: Fail if stage was failed
-    ansible.builtin.fail:
-      msg: "Setup failed"
-    when:
-    - r_result is defined
-    - r_result.rc != 0
+  #- name: Fail if stage was failed
+  #  ansible.builtin.fail:
+  #    msg: "Setup failed"
+  #  when:
+  #  - r_result is defined
+  #  - r_result.rc != 0
 
 - name: Create inventory
   hosts: localhost
@@ -118,13 +119,12 @@
   tasks:
   - name: Add rhel2 host with SSH key
     ansible.builtin.add_host:
-      name: "rhel2"
-      ansible_ssh_pass: ""
+      name: "rhel2post"
       ansible_ssh_user: "root"
       ansible_ssh_private_key_file: "/tmp/{{ guid }}key.pem"
 
 - name: Post task(s) for rhel2
-  hosts: rhel2
+  hosts: rhel2post
   gather_facts: true
   become: true
   vars:

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -120,6 +120,7 @@
   - name: Add rhel2 host with SSH key
     ansible.builtin.add_host:
       name: "rhel2post"
+      ansible_ssh_host: "rhel2"
       ansible_ssh_user: "root"
       ansible_ssh_private_key_file: "/tmp/{{ guid }}key.pem"
 

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -33,7 +33,7 @@
   - debug: var=guid
   - command: ls -R
     register: r_ls
-  - debug: var=r_rls
+  - debug: var=r_ls
   - name: Fetch private SSH key to be used later
     ansible.builtin.fetch:
       src: "/home/rhel/.ssh/{{ guid }}.pem"

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -36,8 +36,8 @@
   - debug: var=r_ls
   - name: Fetch private SSH key to be used later
     ansible.builtin.fetch:
-      src: "/home/rhel/.ssh/{{ guid }}.pem"
-      dest: "/tmp/{{ guid }}.pem"
+      src: "/home/rhel/.ssh/{{ guid }}key.pem"
+      dest: "/tmp/{{ guid }}key.pem"
       flat: yes
   
 
@@ -118,7 +118,7 @@
       ansible_ssh_host: ""
       ansible_ssh_user: "{{ lookup('ansible.builtin.env', 'BASTION_USER') }}"
       ansible_ssh_pass: ""
-      ansible_ssh_private_keyfile: "/tmp/{{ guid }}.pem"
+      ansible_ssh_private_keyfile: "/tmp/{{ guid }}key.pem"
 
 - name: Post task(s) for rhel2
   hosts: rhel2

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -117,7 +117,6 @@
     guid: "{{ lookup('ansible.builtin.env', 'GUID') }}"
   tasks:
   - name: Add rhel2 host with SSH key
-    when: false
     ansible.builtin.add_host:
       name: "rhel2"
       ansible_ssh_pass: ""

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -149,6 +149,21 @@
       ansible.builtin.user:
         name: root
         password: "{{ rhel_user_password | password_hash('sha512') }}" # Generates SHA512 hash from prompted password
+
+    - name: Add PermitRootLogin configuration snippet
+      ansible.builtin.copy:
+        content: |
+          PermitRootLogin yes
+        dest: /etc/ssh/sshd_config.d/ansible_permit_root_login.conf
+        owner: root
+        group: root
+        mode: '0644'
+
+    - name: Reload sshd
+      ansible.builtin.service:
+        name: sshd
+        state: reloaded
+
 - name: Create inventory
   hosts: localhost
   gather_facts: false

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -81,7 +81,6 @@
 
   - name: Execute module_stage-host.sh if it exists
     when: r_script_test.stat.exists
-    ignore_errors: true
     shell: "sh -x /tmp/setup-scripts/setup-{{ ansible_host }}.sh > /tmp/setup-scripts/setup-{{ ansible_host }}.log 2>&1"
     become: true
     register: r_result
@@ -104,12 +103,12 @@
       var: r_result
     when: r_result is defined
 
-  #- name: Fail if stage was failed
-  #  ansible.builtin.fail:
-  #    msg: "Setup failed"
-  #  when:
-  #  - r_result is defined
-  #  - r_result.rc != 0
+  - name: Fail if stage was failed
+    ansible.builtin.fail:
+      msg: "Setup failed"
+    when:
+    - r_result is defined
+    - r_result.rc != 0
 
 - name: Create inventory
   hosts: localhost
@@ -121,6 +120,7 @@
     when: false
     ansible.builtin.add_host:
       name: "rhel2"
+      ansible_ssh_pass: ""
       ansible_ssh_private_key_file: "/tmp/{{ guid }}key.pem"
 
 - name: Post task(s) for rhel2

--- a/setup-automation/main.yml
+++ b/setup-automation/main.yml
@@ -116,7 +116,7 @@
   - name: Add rhel2 host with SSH key
     ansible.builtin.add_host:
       name: "rhel2"
-      ansible_ssh_host: ""
+      ansible_ssh_host: "rhel2"
       ansible_ssh_user: "root"
       ansible_ssh_pass: ""
       ansible_ssh_private_keyfile: "/tmp/{{ guid }}key.pem"

--- a/setup-automation/setup-rhel2.sh
+++ b/setup-automation/setup-rhel2.sh
@@ -2,6 +2,3 @@
 
 ## Convert the system to Image Mode
 podman run --rm --privileged -v /dev:/dev -v /var/lib/containers:/var/lib/containers -v /:/target --pid=host --security-opt label=type:unconfined_t quay.io/toharris/rhel-bootc:summit-2025 bootc install to-existing-root --root-ssh-authorized-keys /target/root/.ssh/authorized_keys --acknowledge-destructive
-
-## Reboot system
-reboot

--- a/setup-automation/setup-rhel2.sh
+++ b/setup-automation/setup-rhel2.sh
@@ -1,1 +1,7 @@
 #!/bin/bash
+
+## Convert the system to Image Mode
+podman run --rm --privileged -v /dev:/dev -v /var/lib/containers:/var/lib/containers -v /:/target --pid=host --security-opt label=type:unconfined_t quay.io/toharris/rhel-bootc:summit-2025 bootc install to-existing-root --root-ssh-authorized-keys /target/root/.ssh/authorized_keys --acknowledge-destructive
+
+## Reboot system
+reboot


### PR DESCRIPTION
- Moved the podman run of rhel-bootc from 02-image-mode (runtime-automation) to setup-automation/setup-rhel2.sh
- Removed the reboot command
- Configure the main.yml
- - Fetch "/home/rhel/.ssh/{{ guid }}key.pem" (internal private ssh key used by agnosticv/agnosticd) from rhel2
- - Run the setup-automation scripts
- - Post configure rhel2:
- - -  Connecting using the private key
- - - Re-add rhel user
- - - Set root password
- - - Permit Root login with password