### PR TITLE
fix RHEL9-> RHEL10 typo on 05-custom-repo.adoc

### DIFF
--- a/content/modules/ROOT/pages/05-custom-repo.adoc
+++ b/content/modules/ROOT/pages/05-custom-repo.adoc
@@ -125,7 +125,7 @@ tee ~/customrepopublishpromote.yml << EOF
       organization: "Acme Org"
       name: "RHEL10"
       repositories:
-        - name: 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS RPMs 9'
+        - name: 'Red Hat Enterprise Linux 10 for x86_64 - BaseOS RPMs 10'
           product: 'Red Hat Enterprise Linux for x86_64'
         - name: 'My custom repository'
           product: 'My custom product'


### PR DESCRIPTION
There is a typo (probably due to history) on the playbook "Update RHEL10 content view" with rhel 9 repositories instead of rhel10 one. 

I just change to make it working without any change